### PR TITLE
Fine-tuned config

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -4,8 +4,8 @@
 unsigned int Config::currentScore = 0;
 
 // Window.
-unsigned int Config::windowWidth = 1440;
-unsigned int Config::windowHeight = 1080;
+unsigned int Config::windowWidth = 1024;
+unsigned int Config::windowHeight = 768;
 
 // Camera.
 float Config::fieldOfVision = 90.0f;
@@ -16,12 +16,12 @@ float Config::indexOfRefraction = 1.2f;
 float Config::roughness = 0.4f;
 
 // Obstacles.
-unsigned int Config::obstacleAmount = 6;
-float Config::obstacleLeftOverhang = 0.5;
-float Config::obstacleLowerBound = 0.33f;
-float Config::obstacleUpperBound = 0.66f;
-float Config::obstacleGapHeight = 0.33f;
-float Config::obstacleDistance = 0.66f;
+unsigned int Config::obstacleAmount = 5;
+float Config::obstacleLeftOverhang = 1.0f;
+float Config::obstacleLowerBound = 0.3f;
+float Config::obstacleUpperBound = 0.7f;
+float Config::obstacleGapHeight = 0.3f;
+float Config::obstacleDistance = 1.1f;
 float Config::obstacleWidth = 0.1f;
 float Config::obstacleDepth = 1.0f;
 float Config::obstacleSpeed = -0.01f;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -17,6 +17,7 @@ float Config::roughness = 0.4f;
 
 // Obstacles.
 unsigned int Config::obstacleAmount = 5;
+float Config::obstacleInitialOffset = 2.0f;
 float Config::obstacleLeftOverhang = 1.0f;
 float Config::obstacleLowerBound = 0.3f;
 float Config::obstacleUpperBound = 0.7f;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -16,7 +16,7 @@ class Config {
     static float debugRotation;              /**< Amount of debug rotation to apply (used in debug mode). */
     static bool showHitbox;                  /**< Whether to show the collision-hit-boxes. */
     static unsigned int obstacleAmount;      /**< Number of obstacles to spawn. */
-    static float obstacleInitialOffset;      /**< Overhang to the left of the window. */
+    static float obstacleInitialOffset;      /**< Initial offset to the right of the window. */
     static float obstacleLeftOverhang;       /**< Overhang to the left of the window. */
     static float obstacleLowerBound;         /**< Lower bound of the height of the obstacle. */
     static float obstacleUpperBound;         /**< Upper bound of the height of the obstacle. */

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -16,6 +16,7 @@ class Config {
     static float debugRotation;              /**< Amount of debug rotation to apply (used in debug mode). */
     static bool showHitbox;                  /**< Whether to show the collision-hit-boxes. */
     static unsigned int obstacleAmount;      /**< Number of obstacles to spawn. */
+    static float obstacleInitialOffset;      /**< Overhang to the left of the window. */
     static float obstacleLeftOverhang;       /**< Overhang to the left of the window. */
     static float obstacleLowerBound;         /**< Lower bound of the height of the obstacle. */
     static float obstacleUpperBound;         /**< Upper bound of the height of the obstacle. */

--- a/src/drawables/obstacles/obstacle.cpp
+++ b/src/drawables/obstacles/obstacle.cpp
@@ -15,7 +15,7 @@ Obstacle::Obstacle(float offset, const std::shared_ptr<FloppyMesh>& upperPartMes
                    const std::shared_ptr<FloppyMesh>& lowerPartMesh)
     : _upperPart(Part(upperPartMesh)),
       _lowerPart(Part(lowerPartMesh)),
-      _offset(offset),
+      _initialOffset(offset),
       _height(Config::obstacleGapHeight),
       _width(Config::obstacleWidth),
       _depth(Config::obstacleDepth),
@@ -27,7 +27,7 @@ Obstacle::Obstacle(Obstacle const& o)
       _height(o._height),
       _width(o._width),
       _depth(o._depth),
-      _offset(o._offset),
+      _initialOffset(o._initialOffset),
       _lightPosition(o._lightPosition),
       _position(o._position) {}
 Obstacle::~Obstacle() {}
@@ -38,7 +38,7 @@ void Obstacle::init() {
     _lowerPart.init();
 
     // Place the obstacle to the right of the window.
-    _position.x = 1 + _offset + (_width / 2);
+    _position.x = 1 + _initialOffset + (_width / 2);
 
     // Reset the individual parts.
     reset();

--- a/src/drawables/obstacles/obstacle.h
+++ b/src/drawables/obstacles/obstacle.h
@@ -52,7 +52,7 @@ class Obstacle : public Drawable {
     glm::vec3 _lightPosition; /**< Position of the light source. */
     Part _upperPart;          /**< Lower part of the Obstacle. */
     Part _lowerPart;          /**< Upper part of the Obstacle. */
-    float _offset;            /**< X-offset from the origin. */
+    float _initialOffset;     /**< X-offset from the origin. */
     float _height;            /**< Height of the obstacle. */
     float _width;             /**< Width of the obstacle. */
     float _depth;             /**< Depth of the obstacle. */

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -49,7 +49,6 @@ GLMainWindow::GLMainWindow() : _updateTimer(this) {
     };
 
     // Create the in the Config specified amount of obstacles and add it to the drawables.
-    float offset = Config::obstacleDistance;
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_real_distribution<float> dist(-45.0f, 45.0f);
@@ -57,7 +56,8 @@ GLMainWindow::GLMainWindow() : _updateTimer(this) {
         auto upperMesh = std::make_shared<FloppyMesh>("res/Sign.obj", 2.0f, dist(mt));
         auto lowerMesh = std::make_shared<FloppyMesh>("res/Lamp.obj", 1.0f, dist(mt));
         // Create the obstacle itself.
-        auto obstacle = std::make_shared<Obstacle>(i * offset, upperMesh, lowerMesh);
+        float initialOffset = Config::obstacleInitialOffset + (i * Config::obstacleDistance);
+        auto obstacle = std::make_shared<Obstacle>(initialOffset, upperMesh, lowerMesh);
 
         // Push this into _drawables to init, update, draw.
         _drawables.push_back(obstacle);

--- a/src/shaders/cookTorrance.fs.glsl
+++ b/src/shaders/cookTorrance.fs.glsl
@@ -1,7 +1,7 @@
 #version 410 core
 
 // NOTE: this must be the same as Config::obstacleAmount
-#define NUM_LIGHTS 6
+#define NUM_LIGHTS 5
 
 // Get values from vertex shader.
 smooth in vec2 vTexCoords;

--- a/src/shaders/cookTorrance.vs.glsl
+++ b/src/shaders/cookTorrance.vs.glsl
@@ -1,7 +1,7 @@
 #version 410 core
 
 // NOTE: this must be the same as Config::obstacleAmount
-#define NUM_LIGHTS 6
+#define NUM_LIGHTS 5
 
 uniform mat4 projection_matrix;
 uniform mat4 modelview_matrix;


### PR DESCRIPTION
The amount of obstacles on the screen and some other details were still very different from the original Flappy Bird.

This PR:
- reduces the number of obstacles on the screen by increasing the distance between them
- adjusts obstacle heights and gap a bit
- spaws the obstacles further to the right in the beginning
- adjusts the window width and height to better fit smaller screens (debatable change)